### PR TITLE
Build fix

### DIFF
--- a/MyApp/Program.cs
+++ b/MyApp/Program.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using ServiceStack;
 
 namespace MyApp
 {
@@ -15,12 +14,11 @@ namespace MyApp
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseModularStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/MyApp/Startup.cs
+++ b/MyApp/Startup.cs
@@ -19,6 +19,8 @@ namespace MyApp
 {
     public class Startup : ModularStartup
     {
+        public Startup(IConfiguration configuration) => Configuration = configuration;
+
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public new void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
I've been unable to build some of the templates using web cli tool. Under NET Core 3.1 (or 3.0) the `UseModularStartup` method is unrecognized. In addition the `Startup` class has a null reference on `Configuration` property which results in exceptions thrown in `NetCoreAppSettings`. This PR fixes this and probably a lot of the other templates.
